### PR TITLE
Fix PHP 7

### DIFF
--- a/lib/class.ABF.php
+++ b/lib/class.ABF.php
@@ -642,7 +642,8 @@ class ABF implements Singleton
         $clientip = $this->getRawClientIP();
 
         // extract the last item from the list
-        $clientip = trim(end(explode(',', $clientip)));
+        $clientip = explode(',', $clientip);
+        $clientip = trim(end($clientip));
 
         return $clientip;
     }

--- a/lib/class.ABF.php
+++ b/lib/class.ABF.php
@@ -385,12 +385,11 @@ class ABF implements Singleton
     {
         $ip = $this->getIP($ip);
         $source = MySQL::cleanValue($source);
-        $results = $this->__isListed($tbl, $ip);
         $isGray = $tbl == $this->TBL_ABF_GL;
         $ret = false;
 
         // do not re-register existing entries
-        if ($results != null && count($results) > 0) {
+        if ($this->__isListed($tbl, $ip)) {
             if ($isGray) {
                 $ret = $this->incrementGrayList($ip);
             }


### PR DESCRIPTION
Passing the result of a function here results in a PHP notice "Only variables should be passed by reference". Passing a variable fixes this.